### PR TITLE
fix: work around golang/go#34627

### DIFF
--- a/format.go
+++ b/format.go
@@ -83,7 +83,19 @@ var defaultVerbsLayout = []string{
 }
 
 var (
-	pid     = os.Getpid()
+	pid = func() (pid int) {
+		if runtime.GOOS == "js" {
+			// This can panic in some wasm contexts.
+			// https://github.com/golang/go/issues/34627
+			defer func() {
+				if recover() != nil {
+					// set the PID to a sane default.
+					pid = 1
+				}
+			}()
+		}
+		return os.Getpid()
+	}()
 	program = filepath.Base(os.Args[0])
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/whyrusleeping/go-logging
+
+go 1.12

--- a/log.go
+++ b/log.go
@@ -51,7 +51,6 @@ func (b *LogBackend) Log(level Level, calldepth int, rec *Record) error {
 	} else {
 		return b.Logger.Output(calldepth+2, rec.Formatted(calldepth+1))
 	}
-	panic("should not be reached")
 }
 
 func colorSeq(color color) string {

--- a/logger_test.go
+++ b/logger_test.go
@@ -47,12 +47,13 @@ func TestPrivateBackend(t *testing.T) {
 		t.Errorf("something in stdBackend, size of backend: %d", stdBackend.size)
 	}
 	if "to private baсkend" == MemoryRecordN(privateBackend, 0).Formatted(0) {
-		t.Errorf("logged to defaultBackend: %s", MemoryRecordN(privateBackend, 0))
+		t.Errorf("logged to defaultBackend: %#v", MemoryRecordN(privateBackend, 0))
 	}
 
 }
 
 type stringTrap bool
+
 func (st *stringTrap) String() string {
 	*st = true
 	return ""
@@ -69,7 +70,7 @@ func TestLoggingMethodsDontStringifyArgsUnduly(t *testing.T) {
 	log.Debug(&trap)
 
 	// make sure all the records get formatted
-	for i := 0; i < int(backend.size) ; i++ {
+	for i := 0; i < int(backend.size); i++ {
 		MemoryRecordN(backend, i).Formatted(0)
 	}
 


### PR DESCRIPTION
os.Getpid() will panic on wasm in browsers (but not in node).

Issue: https://github.com/golang/go/issues/34627